### PR TITLE
Wrap Railtie loaders into an initializer block

### DIFF
--- a/lib/i18nliner/railtie.rb
+++ b/lib/i18nliner/railtie.rb
@@ -4,18 +4,20 @@ require 'i18nliner/extensions/model'
 
 module I18nliner
   class Railtie < Rails::Railtie
-    ActiveSupport.on_load :action_controller do
-      ActionController::Base.send :include, I18nliner::Extensions::Controller
-    end
+    initializer 'i18nliner' do
+      ActiveSupport.on_load :action_controller do
+        ActionController::Base.send :include, I18nliner::Extensions::Controller
+      end
 
-    ActiveSupport.on_load :action_view do
-      require 'i18nliner/erubis'
-      ActionView::Template::Handlers::ERB.erb_implementation = I18nliner::Erubis
-      ActionView::Base.send :include, I18nliner::Extensions::View
-    end
+      ActiveSupport.on_load :action_view do
+        require 'i18nliner/erubis'
+        ActionView::Template::Handlers::ERB.erb_implementation = I18nliner::Erubis
+        ActionView::Base.send :include, I18nliner::Extensions::View
+      end
 
-    ActiveSupport.on_load :active_record do
-      ActiveRecord::Base.send :include, I18nliner::Extensions::Model
+      ActiveSupport.on_load :active_record do
+        ActiveRecord::Base.send :include, I18nliner::Extensions::Model
+      end
     end
 
     rake_tasks do


### PR DESCRIPTION
The `ActiveSupport.on_load` calls need to be wrapped in an `initializer` in the Railtie. Otherwise, they fire immediately when the Railtie class is required.