### PR TITLE
loosen sexp_processor version requirement

### DIFF
--- a/i18nliner.gemspec
+++ b/i18nliner.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = %w(LICENSE.txt Rakefile README.md) + Dir['{lib,spec}/**/*.{rb,rake}']
   s.add_dependency('activesupport', '>= 3.0')
   s.add_dependency('ruby_parser', '~> 3.2')
-  s.add_dependency('sexp_processor', '~> 4.4.0')
+  s.add_dependency('sexp_processor', '~> 4.4')
   s.add_dependency('ruby2ruby', '~> 2.0')
   s.add_dependency('globby', '>= 0.1.1')
   s.add_dependency('erubis', '~> 2.7.0')


### PR DESCRIPTION
sexp_processor seems to stick to a semantic versioning scheme pretty well (and changes pretty slowly, at this point), so it seems safe to allow anything in the 4.x range.  this also allows us to upgrade ruby2ruby past 2.3.1.